### PR TITLE
Update Go version and lint action

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,9 +55,9 @@ jobs:
         run: sudo apt install -y libusb-1.0-0-dev
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
-          version: v1.61.0
+          version: v2.0
           args: --verbose --timeout 5m0s
 
   shellcheck:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,10 +36,10 @@ jobs:
     name: "Lint"
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.23
+      - name: Set up Go 1.24
         uses: actions/setup-go@v5
         with:
-          go-version: "1.23"
+          go-version: "1.24"
         id: go
 
       - name: Check out code into the Go module directory

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/achilleas-k/g13-ak
 
-go 1.23.4
+go 1.24.1
 
 require (
 	github.com/bendahl/uinput v1.7.0

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -317,7 +317,7 @@ func TestGetImageErrors(t *testing.T) {
 
 		fp, err := os.OpenFile(filepath.Join(tmpdir, "0.bmp"), os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0000)
 		assert.NoError(err)
-		fp.Close()
+		_ = fp.Close()
 
 		cfg, err := config.NewFromFile(cfgPath)
 		assert.NoError(err)

--- a/internal/device/device.go
+++ b/internal/device/device.go
@@ -103,14 +103,27 @@ func (d *G13Device) Close() {
 			fmt.Fprintf(os.Stderr, "error resetting LCD during shutdown: %s", err)
 		}
 	}
+
 	if d.ctx != nil {
-		defer d.ctx.Close()
+		defer func() {
+			if err := d.ctx.Close(); err != nil {
+				fmt.Fprintf(os.Stderr, "error closing USB context during shutdown: %s", err)
+			}
+		}()
 	}
 	if d.dev != nil {
-		defer d.dev.Close()
+		defer func() {
+			if err := d.dev.Close(); err != nil {
+				fmt.Fprintf(os.Stderr, "error closing USB device during shutdown: %s", err)
+			}
+		}()
 	}
 	if d.cfg != nil {
-		defer d.cfg.Close()
+		defer func() {
+			if err := d.cfg.Close(); err != nil {
+				fmt.Fprintf(os.Stderr, "error closing USB config during shutdown: %s", err)
+			}
+		}()
 	}
 	if d.intf != nil {
 		defer d.intf.Close()


### PR DESCRIPTION
**go.mod: bump Go version to 1.24.1**


---

**github: bump golangci-lint-action**

Update the action to v7, which requires v2 of the tool.

---
