### PR TITLE
Handle device disconnects gracefully

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"image"
+	"maps"
 	"os"
 	"path/filepath"
 
@@ -53,9 +54,7 @@ func (m *G13Config) SetKey(gkey device.KeyBit, kbKey int) {
 // SetKeys maps one or more G13 keys to the given keyboard key. It does not
 // override any mappings not present in keyMap.
 func (m *G13Config) SetKeys(km keyMap) {
-	for gkey, kbkey := range km {
-		m.keyMap[gkey] = kbkey
-	}
+	maps.Copy(m.keyMap, km)
 }
 
 // UnsetKey unmaps a gkey.

--- a/internal/device/device.go
+++ b/internal/device/device.go
@@ -102,31 +102,31 @@ func New() (Device, error) {
 func (d *G13Device) Close() {
 	if d.dev != nil {
 		if err := d.ResetBacklightColour(); err != nil {
-			fmt.Fprintf(os.Stderr, "error resetting backlight during shutdown: %s", err)
+			fmt.Fprintf(os.Stderr, "error resetting backlight during shutdown: %s\n", err)
 		}
 		if err := d.ResetLCD(); err != nil {
-			fmt.Fprintf(os.Stderr, "error resetting LCD during shutdown: %s", err)
+			fmt.Fprintf(os.Stderr, "error resetting LCD during shutdown: %s\n", err)
 		}
 	}
 
 	if d.ctx != nil {
 		defer func() {
 			if err := d.ctx.Close(); err != nil {
-				fmt.Fprintf(os.Stderr, "error closing USB context during shutdown: %s", err)
+				fmt.Fprintf(os.Stderr, "error closing USB context during shutdown: %s\n", err)
 			}
 		}()
 	}
 	if d.dev != nil {
 		defer func() {
 			if err := d.dev.Close(); err != nil {
-				fmt.Fprintf(os.Stderr, "error closing USB device during shutdown: %s", err)
+				fmt.Fprintf(os.Stderr, "error closing USB device during shutdown: %s\n", err)
 			}
 		}()
 	}
 	if d.cfg != nil {
 		defer func() {
 			if err := d.cfg.Close(); err != nil {
-				fmt.Fprintf(os.Stderr, "error closing USB config during shutdown: %s", err)
+				fmt.Fprintf(os.Stderr, "error closing USB config during shutdown: %s\n", err)
 			}
 		}()
 	}

--- a/internal/device/device.go
+++ b/internal/device/device.go
@@ -100,6 +100,10 @@ func New() (Device, error) {
 }
 
 func (d *G13Device) Close() {
+	if d == nil {
+		return
+	}
+
 	if d.dev != nil {
 		if err := d.ResetBacklightColour(); err != nil {
 			fmt.Fprintf(os.Stderr, "error resetting backlight during shutdown: %s\n", err)
@@ -114,24 +118,33 @@ func (d *G13Device) Close() {
 			if err := d.ctx.Close(); err != nil {
 				fmt.Fprintf(os.Stderr, "error closing USB context during shutdown: %s\n", err)
 			}
+			d.ctx = nil
 		}()
 	}
+
 	if d.dev != nil {
 		defer func() {
 			if err := d.dev.Close(); err != nil {
 				fmt.Fprintf(os.Stderr, "error closing USB device during shutdown: %s\n", err)
 			}
+			d.dev = nil
 		}()
 	}
+
 	if d.cfg != nil {
 		defer func() {
 			if err := d.cfg.Close(); err != nil {
 				fmt.Fprintf(os.Stderr, "error closing USB config during shutdown: %s\n", err)
 			}
+			d.cfg = nil
 		}()
 	}
+
 	if d.intf != nil {
-		defer d.intf.Close()
+		defer func() {
+			d.intf.Close()
+			d.intf = nil
+		}()
 	}
 }
 


### PR DESCRIPTION
**device: wait for device on startup**

If the device isn't found during initialisation, don't fail immediately,
but wait and keep trying every 3 seconds.

---

**device: add \n to shutdown errors**


---

**config: replace loop in SetKeys() with maps.Copy()**


---

**g13/main: handle device disconnections**

After multiple read errors, try to reinitialise the device.  This can
handle cases where a device is disconnected.  The reinitialisation will
wait for the device to reconnect.  If the device is still connected but
in a bad state, the error will kill the process.

---

**device: nil-ify all parts of the device on shutdown**

Handles double calls to close without exploding.

---
