### PR TITLE
config: reset stick keys before setting

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -114,19 +114,24 @@ func (cfg *G13Config) GetKeyStates(input uint64) map[int]bool {
 
 		stickKeys := cfg.mapping.stick.keys
 
+		kbkeys[stickKeys.Up] = false
+		kbkeys[stickKeys.Down] = false
+		kbkeys[stickKeys.Left] = false
+		kbkeys[stickKeys.Right] = false
+
 		// get the stick position and add the mapped key(s)
 		x, y := device.StickPosition(input)
-		if x <= activeZone && stickKeys.Left != 0 {
-			kbkeys[stickKeys.Left] = true
-		}
-		if x >= 255-activeZone && stickKeys.Right != 0 {
-			kbkeys[stickKeys.Right] = true
-		}
 		if y <= activeZone && stickKeys.Up != 0 {
 			kbkeys[stickKeys.Up] = true
 		}
 		if y >= 255-activeZone && stickKeys.Down != 0 {
 			kbkeys[stickKeys.Down] = true
+		}
+		if x <= activeZone && stickKeys.Left != 0 {
+			kbkeys[stickKeys.Left] = true
+		}
+		if x >= 255-activeZone && stickKeys.Right != 0 {
+			kbkeys[stickKeys.Right] = true
 		}
 	}
 	return kbkeys


### PR DESCRIPTION
Set the keys assigned to the stick to false before reading the stick
position, otherwise released keys wont show up in the kbKeys map and
will stay pressed if they were in the previous iteration.
