### PR TITLE
Add virtual joystick support

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -137,9 +137,10 @@ func (cfg *G13Config) GetKeyStates(input uint64) map[int]bool {
 	return kbkeys
 }
 
-func (cfg *G13Config) GetStickState(input uint64) (uint8, uint8) {
-	// NOTE: stick mode is not supported yet, but when eventually the result of
-	// this function will be used to set the joystick position
+// GetStickPosition returns the x, y position of the thumb stick, if it's in
+// stick mode.
+func (cfg *G13Config) GetStickPosition(input uint64) (uint8, uint8) {
+	// TODO: support configurable deadzones
 	if cfg.mapping.stick.mode != StickModeJoystick {
 		return 0, 0
 	}
@@ -235,7 +236,7 @@ func loadConfig(path string) (*G13Config, error) {
 	case "":
 		stickConfig.mode = StickModeOff
 	case "joystick":
-		return nil, fmt.Errorf("stick mode 'joystick' not yet supported")
+		stickConfig.mode = StickModeJoystick
 	case "mouse":
 		return nil, fmt.Errorf("stick mode 'mouse' not yet supported")
 	case "keys":

--- a/internal/joystick/joystick.go
+++ b/internal/joystick/joystick.go
@@ -1,0 +1,61 @@
+package joystick
+
+import (
+	"fmt"
+
+	"github.com/bendahl/uinput"
+)
+
+type Joystick interface {
+	Close() error
+	ButtonPress(b int) error
+	ButtonDown(b int) error
+	ButtonUp(b int) error
+}
+
+type UinputJoystick struct {
+	js uinput.Gamepad
+}
+
+func New(name string) (Joystick, error) {
+	js, err := uinput.CreateGamepad("/dev/uinput", []byte(name), 12, 12)
+	if err != nil {
+		return nil, err
+	}
+	return &UinputJoystick{
+		js: js,
+	}, nil
+}
+
+func (vjs *UinputJoystick) Close() error {
+	if !vjs.hasJoystick() {
+		// just do nothing
+		return nil
+	}
+	return vjs.js.Close()
+}
+
+func (vjs *UinputJoystick) ButtonPress(k int) error {
+	if !vjs.hasJoystick() {
+		return fmt.Errorf("button press before initialising joystick")
+	}
+	return vjs.js.ButtonPress(k)
+}
+
+func (vjs *UinputJoystick) ButtonDown(k int) error {
+	if !vjs.hasJoystick() {
+		return fmt.Errorf("button down before initialising joystick")
+	}
+	return vjs.js.ButtonDown(k)
+}
+
+func (vjs *UinputJoystick) ButtonUp(k int) error {
+	if !vjs.hasJoystick() {
+		return fmt.Errorf("button up before initialising joystick")
+	}
+	return vjs.js.ButtonUp(k)
+}
+
+func (vjs *UinputJoystick) hasJoystick() bool {
+	return vjs.js != nil
+}

--- a/internal/joystick/joystick.go
+++ b/internal/joystick/joystick.go
@@ -11,6 +11,7 @@ type Joystick interface {
 	ButtonPress(b int) error
 	ButtonDown(b int) error
 	ButtonUp(b int) error
+	StickPosition(x, y float32) error
 }
 
 type UinputJoystick struct {
@@ -54,6 +55,13 @@ func (vjs *UinputJoystick) ButtonUp(k int) error {
 		return fmt.Errorf("button up before initialising joystick")
 	}
 	return vjs.js.ButtonUp(k)
+}
+
+func (vjs *UinputJoystick) StickPosition(x, y float32) error {
+	if !vjs.hasJoystick() {
+		return fmt.Errorf("stick position set before initialising joystick")
+	}
+	return vjs.js.LeftStickMove(x, y)
 }
 
 func (vjs *UinputJoystick) hasJoystick() bool {


### PR DESCRIPTION
Add support for creating a virtual joystick that maps to the G13 thumbstick.  The stick mapping can be set using the "joystick" mode under the "stick" config.