### PR TITLE
Fix/joystick/off

### DIFF
--- a/cmd/g13/main.go
+++ b/cmd/g13/main.go
@@ -141,12 +141,14 @@ func g13(cmd *cobra.Command, args []string) error {
 			}
 		}
 
-		xInput, yInput := g13cfg.GetStickPosition(input)
-		xOutput := (float32(xInput) - float32(127)) / float32(127)
-		yOutput := (float32(yInput) - float32(127)) / float32(127)
-		if err := vjs.StickPosition(xOutput, yOutput); err != nil {
-			fmt.Fprintf(os.Stderr, "joystick error setting position %f %f", xOutput, yOutput)
+		stickPos := g13cfg.GetStickPosition(input)
+		if stickPos != nil {
+			xOutput, yOutput := stickPos.UinputPosition()
+			if err := vjs.StickPosition(xOutput, yOutput); err != nil {
+				fmt.Fprintf(os.Stderr, "joystick error setting position %f %f", xOutput, yOutput)
+			}
 		}
+
 	}
 }
 

--- a/cmd/g13/main.go
+++ b/cmd/g13/main.go
@@ -99,8 +99,6 @@ func g13(cmd *cobra.Command, args []string) error {
 		}
 	}()
 
-	_ = vjs
-
 	fmt.Println("Ready")
 	var consecutiveReadErrors uint8 = 0
 	for {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -139,13 +139,14 @@ func (cfg *G13Config) GetKeyStates(input uint64) map[int]bool {
 
 // GetStickPosition returns the x, y position of the thumb stick, if it's in
 // stick mode.
-func (cfg *G13Config) GetStickPosition(input uint64) (uint8, uint8) {
+func (cfg *G13Config) GetStickPosition(input uint64) *StickPosition {
 	// TODO: support configurable deadzones
 	if cfg.mapping.stick.mode != StickModeJoystick {
-		return 0, 0
+		return nil
 	}
 
-	return device.StickPosition(input)
+	x, y := device.StickPosition(input)
+	return &StickPosition{posX: x, posY: y}
 }
 
 func (cfg *G13Config) GetBacklight() [3]uint8 {

--- a/internal/config/joystick.go
+++ b/internal/config/joystick.go
@@ -1,0 +1,30 @@
+package config
+
+type StickPosition struct {
+	posX uint8
+	posY uint8
+}
+
+func (sp *StickPosition) Position() (uint8, uint8) {
+	return sp.posX, sp.posY
+}
+
+func (sp *StickPosition) X() uint8 {
+	return sp.posX
+}
+
+func (sp *StickPosition) Y() uint8 {
+	return sp.posY
+}
+
+func (sp *StickPosition) UinputPosition() (float32, float32) {
+	return sp.UinputX(), sp.UinputY()
+}
+
+func (sp *StickPosition) UinputX() float32 {
+	return (float32(sp.posX) - float32(127)) / float32(127)
+}
+
+func (sp *StickPosition) UinputY() float32 {
+	return (float32(sp.posY) - float32(127)) / float32(127)
+}


### PR DESCRIPTION
Return a nillable StickPosition from GetStickPosition().  Since the 0, 0 values are valid coordinates (top left), returning them when the stick isn't enabled is bad and stupid.