### PR TITLE
gg13: don't nil-ify dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 # Development playground cmd
 cmd/pg
+bin

--- a/cmd/gg13/main.go
+++ b/cmd/gg13/main.go
@@ -144,7 +144,6 @@ func g13(cmd *cobra.Command, args []string) error {
 			if consecutiveReadErrors >= errorCounterThreshold {
 				fmt.Println("Reinitialising device")
 				dev.Close()
-				dev = nil
 				if err := vkb.Close(); err != nil {
 					fmt.Fprintf(os.Stderr, "error closing vkb: %s\n", err)
 				}


### PR DESCRIPTION
Even though we have a nil guard in the Close() method, dev is an
interface type and doesn't call the concrete G13Device() close method
when nil.